### PR TITLE
Adds initial infratographer-changes stream

### DIFF
--- a/compose-env
+++ b/compose-env
@@ -3,24 +3,30 @@ COCKROACH_HOST=crdb:26257
 
 LOCATIONAPI_CRDB_URI="postgresql://root@crdb:26257/location_api?sslmode=disable"
 LOCATIONAPI_EVENTS_PUBLISHER_NATS_CREDSFILE="/nats-creds/user.creds"
+LOCATIONAPI_EVENTS_PUBLISHER_PREFIX=com.infratographer
 LOCATIONAPI_OIDC_ENABLED=false
 
 METADATAAPI_CRDB_URI="postgresql://root@crdb:26257/metadata_api?sslmode=disable"
 METADATAAPI_EVENTS_PUBLISHER_NATS_CREDSFILE="/nats-creds/user.creds"
+METADATAAPI_EVENTS_PUBLISHER_PREFIX=com.infratographer
 METADATAAPI_OIDC_ENABLED=false
 
 TENANTAPI_CRDB_URI="postgresql://root@crdb:26257/tenant_api?sslmode=disable"
 TENANTAPI_EVENTS_PUBLISHER_NATS_CREDSFILE="/nats-creds/user.creds"
+TENANTAPI_EVENTS_PUBLISHER_PREFIX=com.infratographer
 TENANTAPI_OIDC_ENABLED=false
 
 IPAMAPI_CRDB_URI="postgresql://root@crdb:26257/ipam_api?sslmode=disable"
 IPAMAPI_EVENTS_PUBLISHER_NATS_CREDSFILE="/nats-creds/user.creds"
+IPAMAPI_EVENTS_PUBLISHER_PREFIX=com.infratographer
 IPAMAPI_OIDC_ENABLED=false
 
 LOADBALANCERAPI_CRDB_URI="postgresql://root@crdb:26257/load_balancer_api?sslmode=disable"
 LOADBALANCERAPI_EVENTS_PUBLISHER_NATS_CREDSFILE="/nats-creds/user.creds"
+LOADBALANCERAPI_EVENTS_PUBLISHER_PREFIX=com.infratographer
 LOADBALANCERAPI_OIDC_ENABLED=false
 
 RESOURCEPROVIDERAPI_CRDB_URI="postgresql://root@crdb:26257/resource_provider_api?sslmode=disable"
 RESOURCEPROVIDERAPI_EVENTS_PUBLISHER_NATS_CREDSFILE="/nats-creds/user.creds"
+RESOURCEPROVIDERAPI_EVENTS_PUBLISHER_PREFIX=com.infratographer
 RESOURCEPROVIDERAPI_OIDC_ENABLED=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     image: &location_api_image ghcr.io/infratographer/location-api:main-latest
     command: serve --dev
     ports:
-      - "7906:7906"
+      - "7909:7909"
     env_file:
       - compose-env
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,3 +158,32 @@ services:
       - ./nats/api-creds:/api-creds
     command:
       - /scripts/nats_init.sh
+
+  nats-box:
+    image: natsio/nats-box
+    entrypoint: /bin/sleep
+    environment:
+      - NSC_HOME=/nsc
+    volumes:
+      - ./nats/nsc:/nsc
+      - ./nats/config:/nats
+      - ./nats/scripts:/scripts
+      - ./nats/api-creds:/api-creds
+    command:
+      - infinity
+    depends_on:
+      - nats
+
+  nats-stream-init:
+    image: natsio/nats-box
+    environment:
+      - NSC_HOME=/nsc
+    volumes:
+      - ./nats/nsc:/nsc
+      - ./nats/config:/nats
+      - ./nats/scripts:/scripts
+      - ./nats/api-creds:/api-creds
+    command:
+      - /scripts/stream_init.sh
+    depends_on:
+      - nats

--- a/nats/scripts/stream_init.sh
+++ b/nats/scripts/stream_init.sh
@@ -1,0 +1,2 @@
+nats -s nats:4222 --creds=/api-creds/user.creds stream add infratographer-changes --subjects="com.infratographer.>" --storage=file --replicas=1 --retention=limits --discard=old --max-msg
+s=-1 --max-msgs-per-subject=-1 --max-bytes=-1 --max-age=-1 --max-msg-size=-1 --dupe-window=2m0s --allow-rollup --no-deny-delete --no-deny-purge


### PR DESCRIPTION
When you first spin up the stack and attempt to create anything, you'll see a message indicating there is no stream that matches what we want to publish to. This creates an initial stream matching the wildcard prefix so that APIs can begin publishing